### PR TITLE
Adjustable bit size binary fiducials

### DIFF
--- a/applications/src/boofcv/app/BaseFiducialSquareEPS.java
+++ b/applications/src/boofcv/app/BaseFiducialSquareEPS.java
@@ -44,6 +44,10 @@ import java.io.PrintStream;
  */
 public abstract class BaseFiducialSquareEPS {
 
+	// The multiple of a a square inside the grid that the border should be.
+	// In order to work well with the DetectFiducialSquareBi
+	private static final float BLACK_BORDER_MULTIPLE = 2.0F;
+
 	// threshold for converting to a binary image
 	public int threshold = 255/2;
 	public double UNIT_TO_POINTS;
@@ -97,6 +101,7 @@ public abstract class BaseFiducialSquareEPS {
 
 	// stream in which the output file is written to
 	PrintStream out;
+
 
 	public Unit getUnit() {
 		return unit;
@@ -225,8 +230,8 @@ public abstract class BaseFiducialSquareEPS {
 
 		fiducialBoxWidth = fiducialWidthUnit* UNIT_TO_POINTS;
 		whiteBorder = whiteBorderUnit* UNIT_TO_POINTS;
-		blackBorder = fiducialBoxWidth /4.0;
-		innerWidth = fiducialBoxWidth /2.0;
+		blackBorder = getBlackBorderWidth(fiducialBoxWidth);
+		innerWidth = getFiducialInnerWidth(fiducialBoxWidth);
 		fiducialTotalWidth = fiducialBoxWidth +whiteBorder*2;
 
 		//  zone in which the target can't be placed unless it will print inside the border, which is not allowed
@@ -494,4 +499,24 @@ public abstract class BaseFiducialSquareEPS {
 	 * Name of the image which will go into the EPS document
 	 */
 	public abstract String selectEpsName();
+
+	/**
+	 * The width in points of the black border for the fiducial. Subclasses can override this if
+	 * some special calculation is needed for the type of fiducual. The default is fiducialBoxWidth / 4.0 .
+	 * @param fiducialBoxWidth The width of the total fidcual box, NOT including the white border.
+	 * @return the width in points.
+	 */
+	protected double getBlackBorderWidth(final double fiducialBoxWidth) {
+		return fiducialBoxWidth / 4.0;
+	}
+
+	/**
+	 * The width in points of inner area for the fiducial. Subclasses can override this if
+	 * some special calculation is needed for the type of fiducual. The default is fiducialBoxWidth / 2.0 .
+	 * @param fiducialBoxWidth The width of the total fidcual box, NOT including the white border.
+	 * @return the width in points.
+	 */
+	protected double getFiducialInnerWidth(final double fiducialBoxWidth) {
+		return fiducialBoxWidth / 2.0;
+	}
 }

--- a/applications/src/boofcv/app/CommandParserFiducialSquare.java
+++ b/applications/src/boofcv/app/CommandParserFiducialSquare.java
@@ -169,9 +169,8 @@ public class CommandParserFiducialSquare {
 		System.out.println("Print Info           "+printInfo);
 		System.out.println("Print Grid           "+printGrid);
 		System.out.println("Boundary Hack        "+(!noBoundaryHack));
-		if(isBinary) System.out.println("Binary Grid Size    "+ binaryGridSize + "x" + binaryGridSize);
-		if( paper != null )
-			System.out.println("Paper Size       "+paper);
+		if(isBinary) System.out.println("Binary Grid Size     "+ binaryGridSize + "x" + binaryGridSize);
+		if( paper != null )	System.out.println("Paper Size           "+paper);
 		if( gridX < 0)
 			System.out.println("Grid                 automatic");
 		else if( gridX > 1 && gridY > 1)
@@ -190,10 +189,6 @@ public class CommandParserFiducialSquare {
 
 		System.out.println("################### Generating");
 
-		for( String path : patternNames ) {
-			app.addPattern(path);
-		}
-
 		if(app instanceof CreateFiducialSquareBinaryEPS) {
 			switch(binaryGridSize) {
 				case 3:
@@ -208,6 +203,10 @@ public class CommandParserFiducialSquare {
 					((CreateFiducialSquareBinaryEPS) app).setGridSize(BinaryFiducialGridSize.FOUR_BY_FOUR);
 					break;
 			}
+		}
+
+		for( String path : patternNames ) {
+			app.addPattern(path);
 		}
 
 		app.setOutputFileName(outputName);

--- a/applications/src/boofcv/app/CommandParserFiducialSquare.java
+++ b/applications/src/boofcv/app/CommandParserFiducialSquare.java
@@ -190,19 +190,8 @@ public class CommandParserFiducialSquare {
 		System.out.println("################### Generating");
 
 		if(app instanceof CreateFiducialSquareBinaryEPS) {
-			switch(binaryGridSize) {
-				case 3:
-					((CreateFiducialSquareBinaryEPS) app).setGridSize(BinaryFiducialGridSize.THREE_BY_THREE);
-					break;
-				case 5:
-					((CreateFiducialSquareBinaryEPS) app).setGridSize(BinaryFiducialGridSize.FIVE_BY_FIVE);
-					break;
-				default:
-					System.out.println("INVALID Binary Grid Width Specified, defaulting to 4x4");
-				case 4:
-					((CreateFiducialSquareBinaryEPS) app).setGridSize(BinaryFiducialGridSize.FOUR_BY_FOUR);
-					break;
-			}
+			((CreateFiducialSquareBinaryEPS) app).
+					setGridSize(BinaryFiducialGridSize.gridSizeForWidth(binaryGridSize));
 		}
 
 		for( String path : patternNames ) {

--- a/applications/src/boofcv/app/CommandParserFiducialSquare.java
+++ b/applications/src/boofcv/app/CommandParserFiducialSquare.java
@@ -18,6 +18,8 @@
 
 package boofcv.app;
 
+import boofcv.abst.fiducial.BinaryFiducialGridSize;
+
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
@@ -44,6 +46,8 @@ public class CommandParserFiducialSquare {
 	public boolean printGrid = false;
 	public boolean noBoundaryHack = false;
 	public double fiducialWidth = -1;
+	private boolean isBinary = false;
+	private int binaryGridSize = 4;
 
 	public List<String> patternNames = new ArrayList<String>();
 
@@ -77,6 +81,11 @@ public class CommandParserFiducialSquare {
 		System.out.println("                     example: -Units=cm");
 		System.out.println("-PageSize=<type>     Specify the page: A0, A1, A2, A3, A4, legal, letter");
 		System.out.println("                     example: -PageSize=letter");
+		if(isBinary) {
+			System.out.println("-BinaryGridWidth=<n> Specify the width of the grid used to encode binary numbers. Valid values are 3,4 and 5");
+			System.out.println("                     Maximum distinct fiducials: 3 is 32, 4 is 4096, 5 is 2,097,152. Default is 4");
+			System.out.println("                     example: -BinaryGridSize=4");
+		}
 		System.out.println();
 		System.out.println("Examples:");
 		System.out.println("./application -PrintInfo -OutputFile=fiducial.eps 10 "+n0);
@@ -127,6 +136,8 @@ public class CommandParserFiducialSquare {
 					units = Unit.lookup(param(arg));
 				} else if( "PageSize".compareToIgnoreCase(label) == 0 ) {
 					paper = PaperSize.lookup(param(arg));
+				} else if( "BinaryGridWidth".compareToIgnoreCase(label) == 0 ) {
+					binaryGridSize = Integer.parseInt(param(arg));
 				} else {
 					throw new IllegalArgumentException("Unknown: "+label);
 				}
@@ -136,6 +147,8 @@ public class CommandParserFiducialSquare {
 		}
 		return index;
 	}
+
+
 
 	public void execute( String []args , BaseFiducialSquareEPS app) throws IOException {
 		try {
@@ -156,6 +169,7 @@ public class CommandParserFiducialSquare {
 		System.out.println("Print Info           "+printInfo);
 		System.out.println("Print Grid           "+printGrid);
 		System.out.println("Boundary Hack        "+(!noBoundaryHack));
+		if(isBinary) System.out.println("Binary Grid Size    "+ binaryGridSize + "x" + binaryGridSize);
 		if( paper != null )
 			System.out.println("Paper Size       "+paper);
 		if( gridX < 0)
@@ -178,6 +192,22 @@ public class CommandParserFiducialSquare {
 
 		for( String path : patternNames ) {
 			app.addPattern(path);
+		}
+
+		if(app instanceof CreateFiducialSquareBinaryEPS) {
+			switch(binaryGridSize) {
+				case 3:
+					((CreateFiducialSquareBinaryEPS) app).setGridSize(BinaryFiducialGridSize.THREE_BY_THREE);
+					break;
+				case 5:
+					((CreateFiducialSquareBinaryEPS) app).setGridSize(BinaryFiducialGridSize.FIVE_BY_FIVE);
+					break;
+				default:
+					System.out.println("INVALID Binary Grid Width Specified, defaulting to 4x4");
+				case 4:
+					((CreateFiducialSquareBinaryEPS) app).setGridSize(BinaryFiducialGridSize.FOUR_BY_FOUR);
+					break;
+			}
 		}
 
 		app.setOutputFileName(outputName);
@@ -248,5 +278,9 @@ public class CommandParserFiducialSquare {
 	public void setExampleNames( String name0 , String name1 ) {
 		exampleNames.add(name0);
 		exampleNames.add(name1);
+	}
+
+	public void setIsBinary(boolean isBinary) {
+		this.isBinary = isBinary;
 	}
 }

--- a/applications/src/boofcv/app/CreateFiducialSquareBinaryEPS.java
+++ b/applications/src/boofcv/app/CreateFiducialSquareBinaryEPS.java
@@ -107,7 +107,7 @@ public class CreateFiducialSquareBinaryEPS  extends BaseFiducialSquareEPS {
 				transitionBits = new int[]{ 1 ,9 , 11 };
 				break;
 			case FIVE_BY_FIVE:
-				transitionBits = new int[]{ 1 ,17 , 20 };
+				transitionBits = new int[]{ 2 ,17 , 20 };
 				break;
 			default:
 				throw new RuntimeException("Unexpected grid size");

--- a/applications/src/boofcv/app/CreateFiducialSquareBinaryEPS.java
+++ b/applications/src/boofcv/app/CreateFiducialSquareBinaryEPS.java
@@ -18,6 +18,7 @@
 
 package boofcv.app;
 
+import boofcv.abst.fiducial.BinaryFiducialGridSize;
 import org.ddogleg.struct.GrowQueue_I32;
 
 import java.io.IOException;
@@ -33,15 +34,16 @@ public class CreateFiducialSquareBinaryEPS  extends BaseFiducialSquareEPS {
 	// list of the fiducial ID's it will print
 	GrowQueue_I32 numbers = new GrowQueue_I32();
 
+	private BinaryFiducialGridSize gridSize = BinaryFiducialGridSize.FOUR_BY_FOUR;
+
 	@Override
 	protected void printPatternDefinitions() {
 
-		out.print(
-				"  /sl "+(innerWidth/4)+" def\n" +
-				"  /w0 0 def\n" +
-				"  /w1 { w0 sl add} def\n" +
-				"  /w2 { w1 sl add} def\n" +
-				"  /w3 { w2 sl add} def\n");
+		out.print("  /sl "+(innerWidth/gridSize.getWidth())+" def\n  /w0 0 def\n");
+		// Handle different size grids.
+		for(int i = 1; i < gridSize.getWidth(); i++) {
+			out.print("  /w" + i + " { w" + (i-1) + " sl add} def\n");
+		}
 		out.print("  /box {newpath moveto sl 0 rlineto 0 sl rlineto sl neg 0 rlineto closepath fill} def\n");
 
 		for( int i = 0; i < numbers.size(); i++ ) {
@@ -50,7 +52,8 @@ public class CreateFiducialSquareBinaryEPS  extends BaseFiducialSquareEPS {
 			out.print("  /"+getPatternPrintDef(i)+" {\n"+
 					"% Block corner used to identify orientation\n" +
 					"  0 0 box\n");
-			for (int j = 0; j < 12; j++) {
+			final int bitCount = gridSize.getNumberOfElements() - 4;
+			for (int j = 0; j < bitCount; j++) {
 				if( (patternNumber & (1<<j)) != 0 ) {
 					box(out,j);
 				}
@@ -66,9 +69,10 @@ public class CreateFiducialSquareBinaryEPS  extends BaseFiducialSquareEPS {
 
 	@Override
 	protected void addPattern(String name) {
+		final int maxValue = (int) Math.pow(2, gridSize.getNumberOfElements() - 4) - 1;
 		int value = Integer.parseInt(name);
-		if( value < 0 || value > 4095 )
-			throw new IllegalArgumentException("Values must be tween 0 and 4095, inclusive");
+		if( value < 0 || value > maxValue)
+			throw new IllegalArgumentException("Values must be tween 0 and " +maxValue + ", inclusive");
 		numbers.add( Integer.parseInt(name));
 	}
 
@@ -93,29 +97,63 @@ public class CreateFiducialSquareBinaryEPS  extends BaseFiducialSquareEPS {
 			return numbers.get(0)+" and more";
 	}
 
-	private static void box( PrintStream out , int bit ) {
-		if( bit < 2 )
-			bit++;
-		else if( bit < 10 )
-			bit += 2;
-		else if( bit < 12 )
-			bit += 3;
+	private void box( PrintStream out , final int bit ) {
+		final int transitionBits[];
+		switch (gridSize) {
+			case THREE_BY_THREE:
+				transitionBits = new int[]{ 0 ,3 , 4 };
+				break;
+			case FOUR_BY_FOUR:
+				transitionBits = new int[]{ 1 ,9 , 11 };
+				break;
+			case FIVE_BY_FIVE:
+				transitionBits = new int[]{ 1 ,17 , 20 };
+				break;
+			default:
+				throw new RuntimeException("Unexpected grid size");
+		}
+
+		final int adjustedBit;
+		if( bit < transitionBits[0] )
+			adjustedBit = bit + 1;
+		else if( bit < transitionBits[1] )
+			adjustedBit = bit + 2;
+		else if( bit < transitionBits[2] )
+			adjustedBit = bit + 3;
 		else
-			throw new RuntimeException("Bit must be between 0 and 11");
+			throw new RuntimeException("Bit must be between 0 and " + transitionBits[2]);
 
-		int x = bit%4;
-		int y = bit/4;
+		int x = adjustedBit % gridSize.getWidth();
+		int y = adjustedBit / gridSize.getWidth();
+		out.print("  w" + x + " y" + y +" box\n");
+	}
 
-		String wx = "w"+x;
-		String wy = "w"+y;
+	@Override
+	protected double getFiducialInnerWidth(double fiducialBoxWidth) {
+		final double totalWidthInSquares = 2 + gridSize.getWidth() + 2; 	// border + bits + border squares.
+		// the whole width of the fiducial (including border), broken into squares,
+		// then the number of squares in the grid.
+		return fiducialBoxWidth / totalWidthInSquares * gridSize.getWidth();
+	}
 
-		out.print("  "+wx+" "+wy+" box\n");
+	@Override
+	protected double getBlackBorderWidth(double fiducialBoxWidth) {
+		// To work properly with DetectFidualSquareBinary, we need to make
+		// sure the border is a multiple of 2 the size of a single square inside
+		// the fiducial.
+		final double totalWidthInSquares = 2 + gridSize.getWidth() + 2; 	// border + bits + border squares.
+		// the whole width of the fiducial, broken into squares, then two of those squares for the border width.
+		return fiducialBoxWidth / totalWidthInSquares * 2;
+	}
+
+	public void setGridSize(BinaryFiducialGridSize gridSize) {
+		this.gridSize = gridSize;
 	}
 
 	public static void main(String[] args) throws IOException {
 
 		CommandParserFiducialSquare parser = new CommandParserFiducialSquare("number");
-
+		parser.setIsBinary(true);
 		parser.setExampleNames("284","845");
 		parser.execute(args,new CreateFiducialSquareBinaryEPS());
 	}

--- a/applications/src/boofcv/app/CreateFiducialSquareBinaryEPS.java
+++ b/applications/src/boofcv/app/CreateFiducialSquareBinaryEPS.java
@@ -114,18 +114,18 @@ public class CreateFiducialSquareBinaryEPS  extends BaseFiducialSquareEPS {
 		}
 
 		final int adjustedBit;
-		if( bit < transitionBits[0] )
+		if( bit <= transitionBits[0] )
 			adjustedBit = bit + 1;
-		else if( bit < transitionBits[1] )
+		else if( bit <= transitionBits[1] )
 			adjustedBit = bit + 2;
-		else if( bit < transitionBits[2] )
+		else if( bit <= transitionBits[2] )
 			adjustedBit = bit + 3;
 		else
 			throw new RuntimeException("Bit must be between 0 and " + transitionBits[2]);
 
 		int x = adjustedBit % gridSize.getWidth();
 		int y = adjustedBit / gridSize.getWidth();
-		out.print("  w" + x + " y" + y +" box\n");
+		out.print("  w" + x + " w" + y +" box\n");
 	}
 
 	@Override

--- a/main/recognition/src/boofcv/abst/fiducial/BinaryFiducialGridSize.java
+++ b/main/recognition/src/boofcv/abst/fiducial/BinaryFiducialGridSize.java
@@ -19,23 +19,41 @@ public enum BinaryFiducialGridSize {
     FIVE_BY_FIVE(5);
 
 
-    private int _elements;
+    private int elementsWide;
 
     BinaryFiducialGridSize(final int elements) {
-            _elements = elements;
+            elementsWide = elements;
     }
 
     public int getWidth() {
-            return _elements;
+            return elementsWide;
     }
 
     public int getNumberOfElements() {
-            return _elements * _elements;
+            return elementsWide * elementsWide;
     }
 
 
     public int getNumberOfDistinctFiducials() {
-        return (int) Math.pow(2, _elements * _elements - 4);
+        return (int) Math.pow(2, elementsWide * elementsWide - 4);
+    }
+
+    public static BinaryFiducialGridSize gridSizeForWidth(int gridWidth) {
+        switch (gridWidth) {
+            case 3:
+                return THREE_BY_THREE;
+            case 4:
+                return FOUR_BY_FOUR;
+            case 5:
+                return FIVE_BY_FIVE;
+            default:
+                throw new IllegalArgumentException("3-5 are the only valid values for gridWidth");
+        }
+    }
+
+    @Override
+    public String toString() {
+        return elementsWide + "x" + elementsWide;
     }
 }
 

--- a/main/recognition/src/boofcv/abst/fiducial/BinaryFiducialGridSize.java
+++ b/main/recognition/src/boofcv/abst/fiducial/BinaryFiducialGridSize.java
@@ -1,0 +1,42 @@
+package boofcv.abst.fiducial;
+
+/**
+ * Represents the number of squares in a binary fiducial. The more squares, the higher the number
+ * of distinct fiducials you can have. Of course, nothing is free, the higher the number
+ * the less accurate recognition is. 3 Pratical types are supported: 3,4 and 5. The way to
+ * calculate how many distinct fiducials you could generate is the following : 2^(N * N - 4).
+ * The -4 is because the four corners are used to correctly orient the square before
+ * decoding the number in it. So, a 3x3 matrix supports 32 markers, 4x4 4096 markers
+ * and 5x5 2,097,152 markers. These three sizes should be good enough for most pratical
+ * purposes.
+ *
+ * @author Nathan Pahucki for Capta360, <a href="mailto:npahucki@gmail.com"> npahucki@gmail.com</a>
+ */
+public enum BinaryFiducialGridSize {
+
+    THREE_BY_THREE(3),
+    FOUR_BY_FOUR(4),
+    FIVE_BY_FIVE(5);
+
+
+    private int _elements;
+
+    BinaryFiducialGridSize(final int elements) {
+            _elements = elements;
+    }
+
+    public int getWidth() {
+            return _elements;
+    }
+
+    public int getNumberOfElements() {
+            return _elements * _elements;
+    }
+
+
+    public int getNumberOfDistinctFiducials() {
+        return (int) Math.pow(2, _elements * _elements - 4);
+    }
+}
+
+

--- a/main/recognition/src/boofcv/abst/fiducial/SquareBinaryMultiple_to_FidcialDetector.java
+++ b/main/recognition/src/boofcv/abst/fiducial/SquareBinaryMultiple_to_FidcialDetector.java
@@ -1,0 +1,107 @@
+package boofcv.abst.fiducial;
+
+import boofcv.alg.fiducial.BaseDetectFiducialSquare;
+import boofcv.alg.fiducial.DetectFiducialSquareBinary;
+import boofcv.alg.fiducial.FoundFiducial;
+import boofcv.struct.calib.IntrinsicParameters;
+import boofcv.struct.image.ImageSingleBand;
+import boofcv.struct.image.ImageType;
+import georegression.struct.se.Se3_F64;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
+
+/**
+ * Enables detecttion with more than one Binary Fiducial algorithm.
+ * Useful if you want to be able to detect several things at the same time.
+ *
+ * @author Nathan Pahucki, <a href="mailto:npahucki@gmail.com"> npahucki@gmail.com</a>
+ */
+public final class SquareBinaryMultiple_to_FidcialDetector<T extends ImageSingleBand,Detector extends BaseDetectFiducialSquare<T>>
+	implements FiducialDetector<T> {
+
+	private final List<DetectFiducialSquareBinary<T>> algs;
+	private double targetWidth;
+	private ImageType<T> type;
+
+
+
+	public SquareBinaryMultiple_to_FidcialDetector(List<DetectFiducialSquareBinary<T>> algs, double targetWidth) {
+		if(algs.isEmpty()) throw new IllegalArgumentException("At least one DetectFiducialSquareBinary must be provided");
+		// Sanity check
+		final Class inputClass = algs.get(0).getInputType();
+		for(DetectFiducialSquareBinary<T> alg : algs) {
+			if(!inputClass.equals(alg.getInputType())) {
+				throw new IllegalArgumentException("All elements in array must have same InputType");
+			}
+		}
+
+		this.type = ImageType.single(algs.get(0).getInputType());
+		this.algs = new ArrayList(algs); // make a copy no one can change it mid iteration
+		this.targetWidth = targetWidth;
+
+	}
+
+
+	@Override
+	public void detect(T input) {
+		for(DetectFiducialSquareBinary<T> alg : algs) {
+			alg.process(input);
+		}
+	}
+
+	@Override
+	public void setIntrinsic(IntrinsicParameters intrinsic) {
+		for(DetectFiducialSquareBinary<T> alg : algs) {
+			alg.setLengthSide(targetWidth);
+			alg.configure(intrinsic, true);
+		}
+
+	}
+
+	@Override
+	public int totalFound() {
+		int total = 0;
+		for(DetectFiducialSquareBinary<T> alg : algs) {
+			total += alg.getFound().size();
+		}
+		return total;
+	}
+
+	@Override
+	public void getFiducialToCamera(int which, Se3_F64 fiducialToCamera) {
+		fiducialToCamera.set(findByIndex(which).targetToSensor);
+	}
+
+	@Override
+	public int getId(int which) {
+		return findByIndex(which).index;
+	}
+
+	@Override
+	public double getWidth(int which) {
+		return targetWidth;
+	}
+
+	@Override
+	public ImageType<T> getInputType() {
+		return this.type;
+	}
+
+
+	private FoundFiducial findByIndex(int idx) {
+		int lastIdx = 0;
+		for (DetectFiducialSquareBinary<T> alg : algs) {
+			int foundInCurrent = alg.getFound().size();
+			if (foundInCurrent > 0 && idx < lastIdx + foundInCurrent) {
+				return alg.getFound().get(idx - lastIdx);
+			} else {
+				lastIdx += foundInCurrent;
+			}
+		}
+		throw new IllegalArgumentException("Invalid index " + idx);
+	}
+
+}

--- a/main/recognition/src/boofcv/alg/fiducial/DetectFiducialSquareBinary.java
+++ b/main/recognition/src/boofcv/alg/fiducial/DetectFiducialSquareBinary.java
@@ -90,11 +90,10 @@ public class DetectFiducialSquareBinary<T extends ImageSingleBand>
         // and w * gridSize.getWidth() for the inner part.
         super(inputToBinary,quadDetector, (w * gridSize.getWidth() + 4 * w) ,inputType);
         this.gridSize = gridSize;
-        final int elCount = gridSize.getWidth();
-        binaryInner.reshape(w * elCount,w * elCount);
-        counts = new int[elCount];
-        classified = new int[elCount];
-        tmp = new int[elCount];
+        binaryInner.reshape(w * gridSize.getWidth(),w * gridSize.getWidth());
+        counts = new int[gridSize.getNumberOfElements()];
+        classified = new int[gridSize.getNumberOfElements()];
+        tmp = new int[gridSize.getNumberOfElements()];
     }
 
     @Override

--- a/main/recognition/src/boofcv/alg/fiducial/DetectFiducialSquareBinary.java
+++ b/main/recognition/src/boofcv/alg/fiducial/DetectFiducialSquareBinary.java
@@ -260,7 +260,10 @@ public class DetectFiducialSquareBinary<T extends ImageSingleBand>
    		this.ambiguityThreshold = ambiguityThreshold;
    	}
 
-    // This is only works well as a visiual representation if the output font is mono spaced.
+	// For troubleshooting.
+	public ImageFloat32 getGrayNoBorder() { return grayNoBorder; }
+
+	// This is only works well as a visiual representation if the output font is mono spaced.
     public void printClassified() {
         System.out.println();
         System.out.println("██████");

--- a/main/recognition/src/boofcv/alg/fiducial/DetectFiducialSquareBinary.java
+++ b/main/recognition/src/boofcv/alg/fiducial/DetectFiducialSquareBinary.java
@@ -18,6 +18,7 @@
 
 package boofcv.alg.fiducial;
 
+import boofcv.abst.fiducial.BinaryFiducialGridSize;
 import boofcv.abst.filter.binary.InputToBinary;
 import boofcv.alg.shapes.polygon.BinaryPolygonDetector;
 import boofcv.factory.filter.binary.FactoryThresholdBinary;
@@ -27,216 +28,253 @@ import boofcv.struct.image.ImageUInt8;
 
 import java.util.Arrays;
 
+
 /**
  * <p>
- * Fiducial which encores a 12-bit number (0 to 4095) using a predetermined pattern.  The inner region is broken up
- * into 4 by 4 grid of 16-squares which are either white or black.  The lower left corner is always back and
+ * Fiducial which encores a 21-bit number (0 to 2097151) using a predetermined pattern.  The inner region is broken up
+ * into 5 by 5 grid of 25-squares which are either white or black.  The lower left corner is always back and
  * while all the other corners are always white.  This allows orientation to be uniquely determined.
- * </p>
- * <center>
- * <img src="doc-files/square_binary.png"/>
- * </center>
- * <p>
+ * <p/>
  * The above image visually shows the fiducials internal coordinate system.  The center of the fiducial is the origin
  * of the coordinate system, e.g. all sides are width/2 distance away from the origin.  +x is to the right, +y is up
  * , and +z out of the paper towards the viewer.  The black orientation corner is pointed out in the image.
  * The fiducial's width refers to the width of each side along the black border NOT the internal encoded image.
  * </p>
- * @author Peter Abeles
+ *
+ * @author Peter Abeles, Nathan Pahucki
  */
 public class DetectFiducialSquareBinary<T extends ImageSingleBand>
 		extends BaseDetectFiducialSquare<T> {
 
-	// converts the input image into a binary one
-	InputToBinary<ImageFloat32> threshold = FactoryThresholdBinary.globalOtsu(0,255,true,ImageFloat32.class);
-	ImageUInt8 binaryInner = new ImageUInt8(1,1);
+    // helper data structures for computing the value of each grid point
+   	int[] counts, classified, tmp;
+    private BinaryFiducialGridSize gridSize;
 
-	// helper data structures for computing the value of each grid point
-	int counts[] = new int[16];
-	int classified[] = new int[16];
+    // converts the input image into a binary one
+   	private InputToBinary<ImageFloat32> threshold = FactoryThresholdBinary.globalOtsu(0, 255, true, ImageFloat32.class);
+   	private ImageUInt8 binaryInner = new ImageUInt8(1,1);
+   	// storage for no border sub-image
+   	private ImageFloat32 grayNoBorder = new ImageFloat32();
 
-	int tmp[] = new int[16];
+   	// size of a square
+   	protected final static int w=11;
+   	protected final static int N=w*w;
 
-	// storage for no border sub-image
-	ImageFloat32 grayNoBorder = new ImageFloat32();
+   	// length of a side on the fiducials in world units
+   	private double lengthSide = 1;
 
-	// size of a square
-	protected final static int r=5;
-	protected final static int w=r*2+1;
-	protected final static int N=w*w;
+   	// ambiguity threshold. 0 to 1.  0 = very strict and 1 = anything goes
+   	// Sets how strict a square must be black or white for it to be accepted.
+   	// TODO: This should be private, but not changing to avoid breaking any subclasses.
+    protected double ambiguityThreshold = 0.4;
 
-	// length of a side on the fiducials in world units
-	private double lengthSide = 1;
+    /**
+     * Configures the fiducial detector, using the default 4x4 grid.
+     *
+     * @param inputType Type of image it's processing
+     */
+    public DetectFiducialSquareBinary(final InputToBinary<T> inputToBinary,
+                                         final BinaryPolygonDetector<T> quadDetector, Class<T> inputType) {
+        this(BinaryFiducialGridSize.FOUR_BY_FOUR, inputToBinary,quadDetector, inputType);
+    }
 
-	// ambiguity threshold. 0 to 1.  0 = very strict and 1 = anything goes
-	// Sets how strict a square must be black or white for it to be accepted.
-	protected double ambiguityThreshold = 0.4;
 
-	/**
-	 * Configures the fiducial detector
-	 *
-	 * @param inputType Type of image it's processing
-	 */
-	public DetectFiducialSquareBinary(InputToBinary<T> inputToBinary, BinaryPolygonDetector<T> quadDetector,  Class<T> inputType) {
-		super(inputToBinary,quadDetector, w*8, inputType);
+    /**
+     * Configures the fiducial detector, specifying the grid type.
+     *
+     * @param inputType Type of image it's processing
+     */
+    public DetectFiducialSquareBinary(final BinaryFiducialGridSize gridSize, final InputToBinary<T> inputToBinary,
+                                         final BinaryPolygonDetector<T> quadDetector, Class<T> inputType) {
+        // Borders should be 2 * w, on each side which means w * 4 for the border,
+        // and w * gridSize.getWidth() for the inner part.
+        super(inputToBinary,quadDetector, (w * gridSize.getWidth() + 4 * w) ,inputType);
+        this.gridSize = gridSize;
+        final int elCount = gridSize.getWidth();
+        binaryInner.reshape(w * elCount,w * elCount);
+        counts = new int[elCount];
+        classified = new int[elCount];
+        tmp = new int[elCount];
+    }
 
-		int widthNoBorder = w*4;
+    @Override
+    protected boolean processSquare(ImageFloat32 gray, Result result) {
+        int off = (gray.width - binaryInner.width) / 2;
+        gray.subimage(off, off, gray.width - off, gray.width - off, grayNoBorder);
 
-		binaryInner.reshape(widthNoBorder, widthNoBorder);
-	}
+        // convert input image into binary number
+        findBitCounts(grayNoBorder);
 
-	/**
-	 * parameters which specifies how tolerant it is of a square being ambiguous black or white.
-	 * @param ambiguityThreshold 0 to 1, insclusive
-	 */
-	public void setAmbiguityThreshold(double ambiguityThreshold) {
-		if( ambiguityThreshold < 0 || ambiguityThreshold > 1 )
-			throw new IllegalArgumentException("Must be from 0 to 1, inclusive");
-		this.ambiguityThreshold = ambiguityThreshold;
-	}
+        if (thresholdBinaryNumber())
+            return false;
 
-	public void setLengthSide(double lengthSide) {
-		this.lengthSide = lengthSide;
-	}
 
-	@Override
-	protected boolean processSquare(ImageFloat32 gray, Result result) {
+        // adjust the orientation until the black corner is in the lower left
+        if (rotateUntilInLowerCorner(result))
+            return false;
 
-		int off = (gray.width- binaryInner.width)/2;
-		gray.subimage(off,off,gray.width-off,gray.width-off,grayNoBorder);
+        result.which = extractNumeral();
+        result.lengthSide = lengthSide;
 
-//		grayNoBorder.printInt();
+        //printClassified();
+        return true;
+    }
 
-		// convert input image into binary number
-		findBitCounts(grayNoBorder);
+    /**
+     * Extract the numerical value it encodes
+     * @return the int value of the numeral.
+     */
+    protected int extractNumeral() {
+        //
+        int val = 0;
+        final int topLeft = gridSize.getNumberOfElements() - gridSize.getWidth();
+        int shift = 0;
 
-		if (thresholdBinaryNumber())
-			return false;
+        // -2 because the top and bottom rows have 2 unusable bits (the first and last)
+        for(int i = 1; i < gridSize.getWidth() - 1; i++) {
+            final int idx = topLeft + i;
+            val |= classified[idx] << shift;
+            //System.out.println("val |= classified[" + idx + "] << " + shift + ";");
+            shift++;
+        }
 
-		// adjust the orientation until the black corner is in the lower left
-		if (rotateUntilInLowerCorner(result))
-			return false;
+        // Don't do the first or last row, handled above and below - special cases
+        for(int ii = 1; ii < gridSize.getWidth() - 1; ii++) {
+            for(int i = 0; i < gridSize.getWidth(); i++) {
+                final int idx = gridSize.getNumberOfElements() - (gridSize.getWidth() * (ii + 1)) + i;
+                val |= classified[idx] << shift;
+                //  System.out.println("val |= classified[" + idx + "] << " + shift + ";");
+                shift++;
+            }
+        }
 
-		// extract the numerical value it encodes
-		int val = 0;
+        // The last row
+        for(int i = 1; i < gridSize.getWidth() - 1; i++) {
+            val |= classified[i] << shift;
+            //System.out.println("val |= classified[" + i + "] << " + shift + ";");
+            shift++;
+        }
 
-		val |= classified[13] << 0;
-		val |= classified[14] << 1;
-		val |= classified[8] << 2;
-		val |= classified[9] << 3;
-		val |= classified[10] << 4;
-		val |= classified[11] << 5;
-		val |= classified[4] << 6;
-		val |= classified[5] << 7;
-		val |= classified[6] << 8;
-		val |= classified[7] << 9;
-		val |= classified[1] << 10;
-		val |= classified[2] << 11;
+        return val;
+    }
 
-		result.which = val;
-		result.lengthSide = lengthSide;
 
-		return true;
-	}
+    /**
+     * Rotate the pattern until the black corner is in the lower right.  Sanity check to make
+     * sure there is only one black corner
+     */
+    private boolean rotateUntilInLowerCorner(Result result) {
+        // sanity check corners.  There should only be one exactly one black
+        final int topLeft = gridSize.getNumberOfElements() - gridSize.getWidth();
+        final int topRight = gridSize.getNumberOfElements() - 1;
+        final int bottomLeft = 0;
+        final int bottomRight = gridSize.getWidth() - 1;
 
-	/**
-	 * Rotate the pattern until the black corner is in the lower right.  Sanity check to make
-	 * sure there is only one black corner
-	 */
-	private boolean rotateUntilInLowerCorner(Result result) {
-		// sanity check corners.  There should only be one exactly one black
-		if( classified[0] + classified[3] + classified[15] + classified[12] != 1 )
-			return true;
 
-		// Rotate until the black corner is in the lower left hand corner on the image.
-		// remember that origin is the top left corner
-		result.rotation = 0;
-		while( classified[12] != 1 ) {
-			result.rotation++;
-			rotateClockWise();
-		}
-		return false;
-	}
+        if (classified[bottomLeft] + classified[bottomRight] + classified[topRight] + classified[topLeft] != 1)
+            return true;
 
-	/**
-	 * Rotate the 4x4 binary clockwise
-	 */
-	protected void rotateClockWise() {
-		tmp[0] = classified[12];
-		tmp[1] = classified[8];
-		tmp[2] = classified[4];
-		tmp[3] = classified[0];
+        // Rotate until the black corner is in the lower left hand corner on the image.
+        // remember that origin is the top left corner
+        result.rotation = 0;
+        while (classified[topLeft] != 1) {
+            result.rotation++;
+            rotateClockWise();
+        }
+        return false;
+    }
 
-		tmp[4] = classified[13];
-		tmp[5] = classified[9];
-		tmp[6] = classified[5];
-		tmp[7] = classified[1];
+    protected void rotateClockWise() {
+        // Swap the four corners
+        for (int ii = 0; ii < gridSize.getWidth(); ii++) {
+            for (int i = 0; i < gridSize.getWidth(); i++) {
+                final int fromIdx = ii * gridSize.getWidth() + i;
+                final int toIdx = (gridSize.getNumberOfElements() - (gridSize.getWidth() * (i + 1))) + ii;
+                tmp[fromIdx] = classified[toIdx];
+            }
+        }
 
-		tmp[8] = classified[14];
-		tmp[9] = classified[10];
-		tmp[10] = classified[6];
-		tmp[11] = classified[2];
+        System.arraycopy(tmp, 0, classified, 0, gridSize.getNumberOfElements());
+    }
 
-		tmp[12] = classified[15];
-		tmp[13] = classified[11];
-		tmp[14] = classified[7];
-		tmp[15] = classified[3];
 
-		System.arraycopy(tmp,0,classified,0,16);
-	}
+    /**
+     * Sees how many pixels were positive and negative in each square region.  Then decides if they
+     * should be 0 or 1 or unknown
+     */
+    protected boolean thresholdBinaryNumber() {
 
-	/**
-	 * Sees how many pixels were positive and negative in each square region.  Then decides if they
-	 * should be 0 or 1 or unknown
-	 */
-	private boolean thresholdBinaryNumber() {
+        int lower = (int) (N * (ambiguityThreshold / 2.0));
+        int upper = (int) (N * (1 - ambiguityThreshold / 2.0));
 
-		int lower = (int)(N*(ambiguityThreshold/2.0));
-		int upper = (int)(N*(1-ambiguityThreshold/2.0));
+        for (int i = 0; i < gridSize.getNumberOfElements(); i++) {
+            if (counts[i] < lower) {
+                classified[i] = 0;
+            } else if (counts[i] > upper) {
+                classified[i] = 1;
+            } else {
+                // it's ambiguous so just fail
+                return true;
+            }
+        }
+        return false;
+    }
 
-		for (int i = 0; i < 16; i++) {
-			if( counts[i] < lower ) {
-				classified[i] = 0;
-			} else if( counts[i] > upper ) {
-				classified[i] = 1;
-			} else {
-				// it's ambiguous so just fail
-				return true;
-			}
-		}
-		return false;
-	}
+    protected void findBitCounts(ImageFloat32 gray) {
+        // compute binary image using an adaptive algorithm to handle shadows
+        threshold.process(gray, binaryInner);
 
-	private void findBitCounts(ImageFloat32 gray) {
-		// compute binary image using an adaptive algorithm to handle shadows
-		threshold.process(gray, binaryInner);
+        Arrays.fill(counts, 0);
+        for (int row = 0; row < gridSize.getWidth(); row++) {
+            int y0 = row * binaryInner.width / gridSize.getWidth();
+            int y1 = (row + 1) * binaryInner.width / gridSize.getWidth();
+            for (int col = 0; col < gridSize.getWidth(); col++) {
+                int x0 = col * binaryInner.width / gridSize.getWidth();
+                int x1 = (col + 1) * binaryInner.width / gridSize.getWidth();
 
-		Arrays.fill(counts,0);
-		for (int row = 0; row < 4; row++) {
-			int y0 = row* binaryInner.width/4;
-			int y1 = (row+1)* binaryInner.width/4;
-			for (int col = 0; col < 4; col++) {
-				int x0 = col* binaryInner.width/4;
-				int x1 = (col+1)* binaryInner.width/4;
+                int total = 0;
+                for (int i = y0; i < y1; i++) {
+                    int index = i * binaryInner.width + x0;
+                    for (int j = x0; j < x1; j++) {
+                        total += binaryInner.data[index++];
+                    }
+                }
 
-				int total = 0;
-				for (int i = y0; i < y1; i++) {
-					int index = i* binaryInner.width + x0;
-					for( int j = x0; j < x1; j++ ) {
-						total += binaryInner.data[index++];
-					}
-				}
+                counts[row * gridSize.getWidth() + col] = total;
+            }
+        }
+    }
 
-				counts[row*4 + col] = total;
-			}
-		}
-	}
+    public void setLengthSide(final double lengthSide) {
+        this.lengthSide = lengthSide;
+    }
 
-	public ImageUInt8 getBinaryInner() {
-		return binaryInner;
-	}
+    public BinaryFiducialGridSize getGridSize() { return gridSize; }
 
-	public ImageFloat32 getGrayNoBorder() {
-		return grayNoBorder;
-	}
+    /**
+   	 * parameters which specifies how tolerant it is of a square being ambiguous black or white.
+   	 * @param ambiguityThreshold 0 to 1, insclusive
+   	 */
+   	public void setAmbiguityThreshold(double ambiguityThreshold) {
+   		if( ambiguityThreshold < 0 || ambiguityThreshold > 1 )
+   			throw new IllegalArgumentException("Must be from 0 to 1, inclusive");
+   		this.ambiguityThreshold = ambiguityThreshold;
+   	}
+
+    // This is only works well as a visiual representation if the output font is mono spaced.
+    public void printClassified() {
+        System.out.println();
+        System.out.println("██████");
+        for (int row = 0; row < gridSize.getWidth(); row++) {
+            System.out.print("█");
+            for (int col = 0; col < gridSize.getWidth(); col++) {
+                System.out.print(classified[row * gridSize.getWidth() + col] == 1 ? "█︎" : "◻");
+            }
+            System.out.print("█");
+            System.out.println();
+        }
+        System.out.println("██████");
+    }
+
 }
+

--- a/main/recognition/src/boofcv/factory/fiducial/ConfigFiducialBinary.java
+++ b/main/recognition/src/boofcv/factory/fiducial/ConfigFiducialBinary.java
@@ -18,6 +18,7 @@
 
 package boofcv.factory.fiducial;
 
+import boofcv.abst.fiducial.BinaryFiducialGridSize;
 import boofcv.factory.shape.ConfigPolygonDetector;
 import boofcv.factory.shape.ConfigRefinePolygonLineToImage;
 import boofcv.struct.Configuration;
@@ -40,6 +41,9 @@ public class ConfigFiducialBinary implements Configuration {
 	 * as black or white.  If it can't be classified then the shape is discarded
 	 */
 	public double ambiguousThreshold = 0.75;
+
+
+	public BinaryFiducialGridSize gridSize = BinaryFiducialGridSize.FOUR_BY_FOUR;
 
 	/**
 	 * Configuration for square detector
@@ -67,6 +71,10 @@ public class ConfigFiducialBinary implements Configuration {
 		if( ambiguousThreshold < 0 || ambiguousThreshold > 1 )
 			throw new IllegalArgumentException("ambiguousThreshold must be from 0 to 1, inclusive");
 	}
+
+	public void setGridSize(BinaryFiducialGridSize gridSize) { this.gridSize = gridSize; }
+
+	public BinaryFiducialGridSize getGridSize() { return gridSize; }
 
 	public double getTargetWidth() {
 		return targetWidth;

--- a/main/recognition/src/boofcv/factory/fiducial/FactoryFiducial.java
+++ b/main/recognition/src/boofcv/factory/fiducial/FactoryFiducial.java
@@ -20,10 +20,7 @@ package boofcv.factory.fiducial;
 
 import boofcv.abst.calib.ConfigChessboard;
 import boofcv.abst.calib.ConfigSquareGrid;
-import boofcv.abst.fiducial.CalibrationFiducialDetector;
-import boofcv.abst.fiducial.FiducialDetector;
-import boofcv.abst.fiducial.SquareBinary_to_FiducialDetector;
-import boofcv.abst.fiducial.SquareImage_to_FiducialDetector;
+import boofcv.abst.fiducial.*;
 import boofcv.abst.filter.binary.InputToBinary;
 import boofcv.alg.fiducial.DetectFiducialSquareBinary;
 import boofcv.alg.fiducial.DetectFiducialSquareImage;
@@ -32,6 +29,9 @@ import boofcv.factory.filter.binary.ConfigThreshold;
 import boofcv.factory.filter.binary.FactoryThresholdBinary;
 import boofcv.factory.shape.FactoryShapeDetector;
 import boofcv.struct.image.ImageSingleBand;
+
+import java.util.ArrayList;
+import java.util.List;
 
 /**
  * Factory for creating fiducial detectors which implement {@link FiducialDetector}.
@@ -51,20 +51,33 @@ public class FactoryFiducial {
 	 * @return FiducialDetector
 	 */
 	public static <T extends ImageSingleBand>
-	FiducialDetector<T> squareBinary( ConfigFiducialBinary configFiducial,
-									  ConfigThreshold configThreshold,
-									  Class<T> imageType ) {
+	FiducialDetector<T> squareBinary( final ConfigFiducialBinary configFiducial,
+									  final ConfigThreshold configThreshold,
+									  final Class<T> imageType ) {
 
 		configFiducial.squareDetector.clockwise = false;
 
-		InputToBinary<T> binary = FactoryThresholdBinary.threshold(configThreshold, imageType);
-		BinaryPolygonDetector<T> squareDetector = FactoryShapeDetector.
+		final InputToBinary<T> binary = FactoryThresholdBinary.threshold(configThreshold, imageType);
+		final BinaryPolygonDetector<T> squareDetector = FactoryShapeDetector.
 				polygon(configFiducial.squareDetector,imageType);
 
-		DetectFiducialSquareBinary<T> alg = new DetectFiducialSquareBinary<T>(binary,squareDetector,imageType);
-		alg.setAmbiguityThreshold(configFiducial.ambiguousThreshold);
+		if(configFiducial.gridSize == null) {
+			// Config with all sizes.
+			final List<DetectFiducialSquareBinary<T>> algs = new ArrayList<DetectFiducialSquareBinary<T>>() {
+				{
+					add(new DetectFiducialSquareBinary<T>(BinaryFiducialGridSize.THREE_BY_THREE, binary,squareDetector,imageType));
+					add(new DetectFiducialSquareBinary<T>(BinaryFiducialGridSize.FOUR_BY_FOUR, binary,squareDetector,imageType));
+					add(new DetectFiducialSquareBinary<T>(BinaryFiducialGridSize.FIVE_BY_FIVE, binary,squareDetector,imageType));
+				}
+			};
+			return new SquareBinaryMultiple_to_FidcialDetector<>(algs,configFiducial.targetWidth);
+		} else {
+			final DetectFiducialSquareBinary<T> alg = new DetectFiducialSquareBinary<T>(configFiducial.gridSize, binary,squareDetector,imageType);
+			alg.setAmbiguityThreshold(configFiducial.ambiguousThreshold);
+			return new SquareBinary_to_FiducialDetector<T>(alg,configFiducial.targetWidth);
+		}
 
-		return new SquareBinary_to_FiducialDetector<T>(alg,configFiducial.targetWidth);
+
 	}
 
 	/**

--- a/main/recognition/src/boofcv/factory/fiducial/FactoryFiducial.java
+++ b/main/recognition/src/boofcv/factory/fiducial/FactoryFiducial.java
@@ -70,7 +70,7 @@ public class FactoryFiducial {
 					add(new DetectFiducialSquareBinary<T>(BinaryFiducialGridSize.FIVE_BY_FIVE, binary,squareDetector,imageType));
 				}
 			};
-			return new SquareBinaryMultiple_to_FidcialDetector<>(algs,configFiducial.targetWidth);
+			return new SquareBinaryMultiple_to_FidcialDetector<T,DetectFiducialSquareBinary<T>>(algs,configFiducial.targetWidth);
 		} else {
 			final DetectFiducialSquareBinary<T> alg = new DetectFiducialSquareBinary<T>(configFiducial.gridSize, binary,squareDetector,imageType);
 			alg.setAmbiguityThreshold(configFiducial.ambiguousThreshold);


### PR DESCRIPTION
Allows Binary Fiducials to work with 3, 4, or 5 squares in the grid. The reason for this is that in some uses cases (mine is one) the 4096 elements that 4x4 gives you is simply not enough. In other cases, you may need just a few but want better recognition (using 3x3). 

This pull request adds the required logic for this functionality, and also modifies the command line tools in  the applications module to expose the functionality. 

In particular, the CreateFiducialSquareBinaryEPS now takes an optional parameter --BinaryGridWidth which can be set to 3, 4 or 5. This will generate the binary fiducials using the specified parameter. Additionally, the WebcamTrackFiducial accepts an optional parameter --GridWidth, which may be 3, 4, 5 or ALL. If one of 3,4,5 are specified, then the detector will only work grids of that size. If ALL is specified, then the camera will detect all 3 types simultaneously, even if all present in the camera at the same time. 

** All unit tests still pass in the recognition module **

I hope the community finds this useful, and thank you for putting together this great and VERY well documented project. 
