### PR TITLE
Fix creating multiple page fiducal output.

### DIFF
--- a/applications/src/boofcv/app/BaseFiducialSquare.java
+++ b/applications/src/boofcv/app/BaseFiducialSquare.java
@@ -336,13 +336,15 @@ public abstract class BaseFiducialSquare {
 			printPageHeader(i+1);
 			if(boundaryHack)
 				printInvisibleBoundary();
-			printPatternDefinitions();
-
 			int startPattern = i*patternsPerPage;
+			// Just put the definitions needed for this page
+			printPatternDefinitions(startPattern, patternsPerPage);
 
 			if (printInfo) {
-				for (int pattern = 0; pattern < totalPatterns(); pattern++) {
-					String patternName = getPatternName(startPattern+pattern);
+				// Just put the ones on this page that belong on this page
+				for (int ii = 0; ii < patternsPerPage; ii++) {
+					final int pattern = ii + startPattern;
+					String patternName = getPatternName(pattern);
 					out.print(" /" + getDisplayDef(pattern) + "\n" +
 							"{\n" +
 							"  /Times-Roman findfont\n" + "7 scalefont setfont b1 " + (fiducialTotalWidth - 10) +
@@ -377,8 +379,10 @@ public abstract class BaseFiducialSquare {
 	/**
 	 * Creates definitions which will render the pattern.  Each pattern's difintion will have the name returned
 	 * by {@link #getPatternPrintDef(int)}
+	 * @param startPattern
+	 * @param numberOfPatterns
 	 */
-	protected abstract void printPatternDefinitions();
+	protected abstract void printPatternDefinitions(final int startPattern, final int numberOfPatterns);
 
 	/**
 	 * Returns the total number of unqiue patterns
@@ -410,7 +414,7 @@ public abstract class BaseFiducialSquare {
 				"%%EndComments\n" +
 				"%%BeginProlog\n" +
 				"%%EndProlog\n" +
-				"%%Pages: 1\n");
+				"%%Pages: "+totalPages+"\n");
 	}
 
 	private void printPageHeader( int pageNumber ) {

--- a/applications/src/boofcv/app/CreateFiducialSquareBinary.java
+++ b/applications/src/boofcv/app/CreateFiducialSquareBinary.java
@@ -61,11 +61,6 @@ public class CreateFiducialSquareBinary extends BaseFiducialSquare {
 		}
 	}
 
-	protected void printStandardPatternDefinitions() {
-
-	}
-
-
 	@Override
 	protected int totalPatterns() {
 		return numbers.size();

--- a/applications/src/boofcv/app/CreateFiducialSquareBinary.java
+++ b/applications/src/boofcv/app/CreateFiducialSquareBinary.java
@@ -36,8 +36,8 @@ public class CreateFiducialSquareBinary extends BaseFiducialSquare {
 	private int gridWidth = 4;
 
 	@Override
-	protected void printPatternDefinitions() {
-
+	protected void printPatternDefinitions(final int startPattern, final int numberOfPatterns) {
+		// This always gets printed, every page
 		out.print("  /sl "+(innerWidth/gridWidth)+" def\n  /w0 0 def\n");
 		// Handle different size grids.
 		for(int i = 1; i < gridWidth; i++) {
@@ -45,9 +45,9 @@ public class CreateFiducialSquareBinary extends BaseFiducialSquare {
 		}
 		out.print("  /box {newpath moveto sl 0 rlineto 0 sl rlineto sl neg 0 rlineto closepath fill} def\n");
 
-		for( int i = 0; i < numbers.size(); i++ ) {
+		// This one, we only print for the patterns specified
+		for( int i = startPattern; i < startPattern + numberOfPatterns; i++ ) {
 			long patternNumber = numbers.get(i);
-
 			out.print("  /"+getPatternPrintDef(i)+" {\n"+
 					"% Block corner used to identify orientation\n" +
 					"  0 0 box\n");
@@ -60,6 +60,11 @@ public class CreateFiducialSquareBinary extends BaseFiducialSquare {
 			out.print("} def\n");
 		}
 	}
+
+	protected void printStandardPatternDefinitions() {
+
+	}
+
 
 	@Override
 	protected int totalPatterns() {

--- a/applications/src/boofcv/app/CreateFiducialSquareImage.java
+++ b/applications/src/boofcv/app/CreateFiducialSquareImage.java
@@ -41,7 +41,7 @@ public class CreateFiducialSquareImage extends BaseFiducialSquare {
 	List<String> imagePaths = new ArrayList<String>();
 
 	@Override
-	protected void printPatternDefinitions() {
+	protected void printPatternDefinitions(final int startPattern, final int numberOfPatterns) {
 		for( int i = 0; i < imagePaths.size(); i++ ) {
 			String imageName = new File(imagePaths.get(i)).getName();
 			ImageUInt8 image = UtilImageIO.loadImage(imagePaths.get(i), ImageUInt8.class);


### PR DESCRIPTION
When -PrintInfo flag was activated, this caused a runtime error. 
We were including the fiducal def on every page even though it was only used on a single page which made the document longer than needed. 
Fix an issue where the document was reporting only a single page in the header. 