### PR TITLE
Change the variable name to match the function name.

### DIFF
--- a/demonstrations/src/boofcv/demonstrations/distort/EquirectangularCylinderApp.java
+++ b/demonstrations/src/boofcv/demonstrations/distort/EquirectangularCylinderApp.java
@@ -105,16 +105,16 @@ public class EquirectangularCylinderApp<T extends ImageBase<T>> extends Demonstr
 		panelImage.addMouseListener(new MouseAdapter() {
 			@Override
 			public void mouseClicked(MouseEvent e) {
-				Point2D_F32 latlon = new Point2D_F32();
+				Point2D_F32 lonlat = new Point2D_F32();
 
 				synchronized (distorter) {
 					EquirectangularTools_F32 tools = distorter.getTools();
 
 					double scale = panelImage.scale;
 					distorter.compute((int) (e.getX() / scale), (int) (e.getY() / scale));
-					tools.equiToLonlatFV(distorter.distX, distorter.distY, latlon);
-					panelRotate.setOrientation(UtilAngle.radianToDegree(latlon.y), UtilAngle.radianToDegree(latlon.x),0);
-					distorter.setDirection(latlon.x, latlon.y, 0);
+					tools.equiToLonlatFV(distorter.distX, distorter.distY, lonlat);
+					panelRotate.setOrientation(UtilAngle.radianToDegree(lonlat.y), UtilAngle.radianToDegree(lonlat.x),0);
+					distorter.setDirection(lonlat.x, lonlat.y, 0);
 					distortImage.setModel(distorter); // let it know the transform has changed
 
 					if (inputMethod == InputMethod.IMAGE) {

--- a/demonstrations/src/boofcv/demonstrations/distort/EquirectangularPinholeApp.java
+++ b/demonstrations/src/boofcv/demonstrations/distort/EquirectangularPinholeApp.java
@@ -140,7 +140,7 @@ public class EquirectangularPinholeApp<T extends ImageBase<T>> extends Demonstra
 		MouseAdapter mouseAdapter = new MouseAdapter() {
 			@Override
 			public void mouseClicked(MouseEvent e) {
-				Point2D_F32 latlon = new Point2D_F32();
+				Point2D_F32 lonlat = new Point2D_F32();
 
 				double scale = panelEqui.scale;
 
@@ -151,8 +151,8 @@ public class EquirectangularPinholeApp<T extends ImageBase<T>> extends Demonstra
 					return;
 				panelPinhole.grabFocus();
 				synchronized (imageLock) {
-					distorter.getTools().equiToLonlatFV(x,y,latlon);
-					distorter.setDirection(latlon.x,latlon.y,0);
+					distorter.getTools().equiToLonlatFV(x,y,lonlat);
+					distorter.setDirection(lonlat.x,lonlat.y,0);
 
 					// pinhole has a canonical view along +z
 					// equirectangular lon-lat uses +x

--- a/demonstrations/src/boofcv/demonstrations/distort/EquirectangularRotatingApp.java
+++ b/demonstrations/src/boofcv/demonstrations/distort/EquirectangularRotatingApp.java
@@ -93,16 +93,16 @@ public class EquirectangularRotatingApp<T extends ImageBase<T>> extends Demonstr
 		panelImage.addMouseListener(new MouseAdapter() {
 			@Override
 			public void mouseClicked(MouseEvent e) {
-				Point2D_F32 latlon = new Point2D_F32();
+				Point2D_F32 lonlat = new Point2D_F32();
 
 				synchronized (distorter) {
 					EquirectangularTools_F32 tools = distorter.getTools();
 
 					double scale = panelImage.scale;
 					distorter.compute((int) (e.getX() / scale), (int) (e.getY() / scale));
-					tools.equiToLonlatFV(distorter.distX, distorter.distY, latlon);
-					panelRotate.setOrientation(UtilAngle.radianToDegree(latlon.y), UtilAngle.radianToDegree(latlon.x),0);
-					distorter.setDirection(latlon.x, latlon.y, 0);
+					tools.equiToLonlatFV(distorter.distX, distorter.distY, lonlat);
+					panelRotate.setOrientation(UtilAngle.radianToDegree(lonlat.y), UtilAngle.radianToDegree(lonlat.x),0);
+					distorter.setDirection(lonlat.x, lonlat.y, 0);
 					distortImage.setModel(distorter); // let it know the transform has changed
 
 					if (inputMethod == InputMethod.IMAGE) {

--- a/main/boofcv-geo/src/boofcv/alg/distort/spherical/EquirectangularDistortBase_F32.java
+++ b/main/boofcv-geo/src/boofcv/alg/distort/spherical/EquirectangularDistortBase_F32.java
@@ -67,7 +67,7 @@ public abstract class EquirectangularDistortBase_F32 extends PixelTransform2_F32
 	 * @param pitch Radian from -pi/2 to pi/2
 	 * @param roll Radian from -pi to pi
 	 */
-	public void setDirection(float yaw, float pitch, float roll ) {
+	public void setDirection(float pitch, float yaw, float roll ) {
 		ConvertRotation3D_F32.eulerToMatrix(EulerType.YZX,pitch,yaw,roll,R);
 	}
 

--- a/main/boofcv-geo/src/boofcv/alg/distort/spherical/EquirectangularTools_F32.java
+++ b/main/boofcv-geo/src/boofcv/alg/distort/spherical/EquirectangularTools_F32.java
@@ -125,8 +125,8 @@ public class EquirectangularTools_F32 {
 	 * @param lonlat  (output) x = longitude, y = latitude
 	 */
 	public void equiToLonlatFV(float x , float y , Point2D_F32 lonlat ) {
-		lonlat.x = (x/width - 0.5f)*GrlConstants.F_PI2; // longitude
-		lonlat.y = ((height-y-1.0f)/(height-1) - 0.5f)*GrlConstants.F_PI; // latitude
+		lonlat.x = ((height-y-1.0f)/(height-1) - 0.5f)*GrlConstants.F_PI; // latitude
+		lonlat.y = (x/width - 0.5f)*GrlConstants.F_PI2; // longitude
 	}
 
 	/**


### PR DESCRIPTION
In Equirectangular- apps, some variables' name don't match with the function name.

Additionally, as written in javadoc, function equiToLonlatFV is intended to takes two variables x, y in equirectangular coordinate and returns lonlat.x = longitude, lonlat.y = latitude. However, the actual implementation is reversed, which causes the problem above.