### PR TITLE
Shallow cloning on travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: java
 git:
-  depth: false # All branches will be checked out allowing spotless to do its thing
+  depth: 3 # All branches will be checked out allowing spotless to do its thing
 jdk:
   - openjdk14
 install:


### PR DESCRIPTION
According to [https://docs.travis-ci.com/user/customizing-the-build#git-clone-depth](url), Travis CI provide a way to shallow clone a repository. This has the obvious benefit of speed, since you only need to download a small number of commits.