### PR TITLE
Improve GRADLE build Performance

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -12,18 +12,13 @@ ext.libpath = file('./').absolutePath
 
 allprojects {
     tasks.withType(Test).configureEach {
-        maxParallelForks = 4
-    }
-
-    tasks.withType(Test).configureEach {
+        maxParallelForks = Runtime.runtime.availableProcessors().intdiv(2) ?: 1
+        if (!project.hasProperty("createReports")) {
+            reports.html.required = false
+            reports.junitXml.required = false
+        }
         forkEvery = 100
     }
-
-    tasks.withType(Test).configureEach {
-        reports.html.required = false
-        reports.junitXml.required = false
-    }
-
     tasks.withType(JavaCompile).configureEach {
         options.fork = true
     }

--- a/build.gradle
+++ b/build.gradle
@@ -11,6 +11,23 @@ plugins {
 ext.libpath = file('./').absolutePath
 
 allprojects {
+    tasks.withType(Test).configureEach {
+        maxParallelForks = 4
+    }
+
+    tasks.withType(Test).configureEach {
+        forkEvery = 100
+    }
+
+    tasks.withType(Test).configureEach {
+        reports.html.required = false
+        reports.junitXml.required = false
+    }
+
+    tasks.withType(JavaCompile).configureEach {
+        options.fork = true
+    }
+
     apply plugin: 'idea'
     apply plugin: 'eclipse'
     apply plugin: 'com.peterabeles.gversion'


### PR DESCRIPTION

[Parallel test execution maxParallelForks](https://docs.gradle.org/current/userguide/performance.html#parallel_test_execution). Gradle can run multiple test cases in parallel by setting `maxParallelForks`.

[Disable report generation](https://docs.gradle.org/current/userguide/performance.html#report_generation). We can conditionally disable it by setting `reports.html.required = false; reports.junitXml.required = false`. If you need to generate reports, add `-PcreateReports` to the end of Gradle's build command line.

[Process forking options](https://docs.gradle.org/current/userguide/performance.html#forking_options). Gradle will run all tests in a single forked VM by default. This can be problematic if there are a lot of tests or some very memory-hungry ones. We can fork a new test VM after a certain number of tests have run by setting `forkEvery`.

[Compiler daemon](https://docs.gradle.org/current/userguide/performance.html#compiler_daemon). The Gradle Java plugin allows you to run the compiler as a separate process by setting `options.fork = true`. This feature can lead to much less garbage collection and make Gradle’s infrastructure faster. This project has more than 1000 source files. We can consider enabling this feature.


=====================
If there are any inappropriate modifications in this PR, please give me a reply and I will change them.