### PR TITLE
- Security

### DIFF
--- a/change.txt
+++ b/change.txt
@@ -16,8 +16,10 @@ Version : 0.43.2
   - Completely new build system that doesn't use any local files
   - New fragment camera code is available for use
   - Thanks Maxim Dossioukov for getting the first prototype of the build running
+- Security
+  - When de-serializing YAML it now uses Yaml(new SafeConstructor()) to prevent arbitrary code execution
+  - Thanks Letian Yuan for the disclosure
 
-- TODO restrict yaml parsing
 - TODO restrict config parser
 - Image Processing
   - TODO hough circle detector

--- a/integration/boofcv-swing/src/main/java/boofcv/gui/BoofSwingUtil.java
+++ b/integration/boofcv-swing/src/main/java/boofcv/gui/BoofSwingUtil.java
@@ -442,7 +442,6 @@ public class BoofSwingUtil {
 	}
 
 	public static java.util.List<RecentFiles> getListOfRecentFiles( String preferenceName ) {
-
 		Preferences prefs = Preferences.userRoot().node(preferenceName);
 		String encodedString = prefs.get(KEY_RECENT_FILES, "");
 		// See if recent file list exists, if not just return an empty list

--- a/main/boofcv-io/src/main/java/boofcv/io/calibration/CalibrationIO.java
+++ b/main/boofcv-io/src/main/java/boofcv/io/calibration/CalibrationIO.java
@@ -32,7 +32,7 @@ import org.jetbrains.annotations.Nullable;
 import org.yaml.snakeyaml.DumperOptions;
 import org.yaml.snakeyaml.LoaderOptions;
 import org.yaml.snakeyaml.Yaml;
-import org.yaml.snakeyaml.constructor.Constructor;
+import org.yaml.snakeyaml.constructor.SafeConstructor;
 import org.yaml.snakeyaml.representer.Representer;
 
 import java.io.*;
@@ -130,7 +130,7 @@ public class CalibrationIO {
 		var loaderOptions = new LoaderOptions();
 		loaderOptions.setCodePointLimit(30_145_728);
 
-		return new Yaml(new Constructor(new LoaderOptions()), new Representer(dumperOptions),
+		return new Yaml(new SafeConstructor(new LoaderOptions()), new Representer(dumperOptions),
 				dumperOptions, loaderOptions);
 	}
 
@@ -742,7 +742,7 @@ public class CalibrationIO {
 			var representer = new Representer(new DumperOptions());
 			representer.getPropertyUtils().setSkipMissingProperties(true);
 
-			var yaml = new Yaml(new Constructor(new LoaderOptions()), representer);
+			var yaml = new Yaml(new SafeConstructor(new LoaderOptions()), representer);
 			Map<String, Object> map = yaml.load(filtered);
 
 			int width = getOrThrow(map, "image_width");


### PR DESCRIPTION
  - When de-serializing YAML it now uses Yaml(new SafeConstructor()) to prevent arbitrary code execution
  - Thanks Letian Yuan for the disclosure