### PR TITLE
DetectChessboardCornersX: borderBlur set image

### DIFF
--- a/main/boofcv-feature/src/main/java/boofcv/alg/feature/detect/chess/DetectChessboardCornersX.java
+++ b/main/boofcv-feature/src/main/java/boofcv/alg/feature/detect/chess/DetectChessboardCornersX.java
@@ -209,6 +209,7 @@ public class DetectChessboardCornersX {
 		foundNonmax.reset();
 		borderInput.setImage(input);
 		inputInterp.setImage(input);
+		borderBlur.setImage(blurred);
 
 		// The x-corner detector requires a little bit of blur to be applied ot the input image
 		blurFilter.process(input, blurred);


### PR DESCRIPTION
When DetectChessboardCornersX is called via a pyramid detector `.process` will be called multiple times with images of varying dimensions.

`borderBlur` needs to have `setImage` called in order for it to know which dimensions to use when considering _extend_ pixel sampling.